### PR TITLE
enable warnings; use our

### DIFF
--- a/ReadBackwards.pm
+++ b/ReadBackwards.pm
@@ -6,10 +6,9 @@
 package File::ReadBackwards ;
 
 use strict ;
+use warnings ;
 
-use vars qw( $VERSION ) ;
-
-$VERSION = '1.05' ;
+our $VERSION = '1.05' ;
 
 use Symbol ;
 use Fcntl qw( :seek O_RDONLY ) ;

--- a/t/bw.t
+++ b/t/bw.t
@@ -1,15 +1,16 @@
 #!/usr/local/bin/perl -ws
 
 use strict ;
+use warnings ;
 use Test::More ;
 use Fcntl qw( :seek ) ;
 use File::ReadBackwards ;
 use Carp ;
 use File::Temp qw( tempfile );
 
-use vars qw( $opt_v ) ;
+our $opt_v ;
 
-my (undef, $file) = tempfile('bw-XXXXXX', SUFFIX => '.data', TMPDIR => 1, CLEANUP => 1);
+my (undef, $file) = tempfile('bw-XXXXXX', SUFFIX => '.data', TMPDIR => 1, CLEANUP => 1) ;
 
 my $is_crlf = ( $^O =~ /win32/i || $^O =~ /vms/i ) ;
 

--- a/t/large_file.t
+++ b/t/large_file.t
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl -ws
 
 use strict ;
-
+use warnings ;
 use Carp ;
 use Config ;
 use Fcntl qw( :seek ) ;


### PR DESCRIPTION
This drops support for Perls prior to 5.6.  Buuuut nobody cares.

More serious is that it turns warnings on, which could potentially cause warnings to be displayed where they are not already.  That may actually be a good things though?