### PR TITLE
use warnings (selectively); use our

### DIFF
--- a/ReadBackwards.pm
+++ b/ReadBackwards.pm
@@ -6,14 +6,11 @@
 package File::ReadBackwards ;
 
 use strict ;
-
-use vars qw( $VERSION ) ;
-
-$VERSION = '1.05' ;
-
 use Symbol ;
 use Fcntl qw( :seek O_RDONLY ) ;
 use Carp ;
+
+our $VERSION = '1.05' ;
 
 my $max_read_size = 1 << 13 ;
 

--- a/t/bw.t
+++ b/t/bw.t
@@ -1,13 +1,14 @@
 #!/usr/local/bin/perl -ws
 
 use strict ;
+use warnings ;
 use Test::More ;
 use Fcntl qw( :seek ) ;
 use File::ReadBackwards ;
 use Carp ;
 use File::Temp qw( tempfile );
 
-use vars qw( $opt_v ) ;
+our $opt_v ;
 
 my (undef, $file) = tempfile('bw-XXXXXX', SUFFIX => '.data', TMPDIR => 1, CLEANUP => 1);
 

--- a/t/large_file.t
+++ b/t/large_file.t
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl -ws
 
 use strict ;
-
+use warnings ;
 use Carp ;
 use Config ;
 use Fcntl qw( :seek ) ;


### PR DESCRIPTION
slightly too-conservative, but possibly safer alternative to #6.  Turn warnings on in the tests, and use our.  This drops support for Perls prior to 5.6.